### PR TITLE
fix: single line json console logs

### DIFF
--- a/src/Function.SDK.CSharp/BuilderExtensions.cs
+++ b/src/Function.SDK.CSharp/BuilderExtensions.cs
@@ -107,13 +107,7 @@ public static class BuilderExtensions
 
         builder.Logging.AddJsonConsole(options =>
         {
-            options.IncludeScopes = false;
-            options.TimestampFormat = "HH:mm:ssss";
             options.IncludeScopes = true;
-            options.JsonWriterOptions = new()
-            {
-                Indented = true,
-            };
         });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified JSON console logging configuration by removing explicit timestamp formatting and writer indentation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->